### PR TITLE
mavlink: check type on instance getting by device or network port

### DIFF
--- a/src/modules/mavlink/mavlink_main.cpp
+++ b/src/modules/mavlink/mavlink_main.cpp
@@ -331,7 +331,7 @@ Mavlink::get_instance_for_device(const char *device_name)
 	Mavlink *inst;
 
 	LL_FOREACH(::_mavlink_instances, inst) {
-		if (strcmp(inst->_device_name, device_name) == 0) {
+		if ((inst->_protocol == Protocol::SERIAL) && (strcmp(inst->_device_name, device_name) == 0)) {
 			return inst;
 		}
 	}
@@ -346,7 +346,7 @@ Mavlink::get_instance_for_network_port(unsigned long port)
 	Mavlink *inst;
 
 	LL_FOREACH(::_mavlink_instances, inst) {
-		if (inst->_network_port == port) {
+		if ((inst->_protocol == Protocol::UDP) && (inst->_network_port == port)) {
 			return inst;
 		}
 	}


### PR DESCRIPTION
otherwise serial mavlink running in first will occupy default net port 14556 and could be wrongly used for stream configuring instead or udp mavlink running in first will occupy default serial "/dev/ttyS1"and could be wrongly used for stream configuring instead

issue #15558

Please use [PX4 Discuss](http://discuss.px4.io/) or [Slack](http://slack.px4.io/) to align on pull requests if necessary. You can then open draft pull requests to get early feedback.

**Describe problem solved by this pull request**
A clear and concise description of the problem this proposed change will solve.
E.g. For this use case I ran into...

**Describe your solution**
A clear and concise description of what you have implemented.

**Describe possible alternatives**
A clear and concise description of alternative solutions or features you've considered.

**Test data / coverage**
How was it tested? What cases were covered? Logs uploaded to https://review.px4.io/ and screenshots of the important plot parts.

**Additional context**
Add any other related context or media.
